### PR TITLE
Fix email verification flow for client signups

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -23,7 +23,7 @@ export const authController = {
       const { data, error } = await supabase
         .from('clients')
         .insert([
-          { email, password_hash: hashedPassword, full_name, contact_number, status: 'Active' }
+          { email, password_hash: hashedPassword, full_name, contact_number, status: 'Pending' }
         ])
         .select('*')
         .single();
@@ -32,10 +32,31 @@ export const authController = {
         return res.status(500).json({ error: error.message });
       }
 
-      // Send Welcome message
-      await sendWelcomeEmail(email, full_name);
+      // Generate 6-digit OTP
+      const otp = Math.floor(100000 + Math.random() * 900000).toString();
+      const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
 
-      return res.status(201).json({ message: 'Registration successful', data });
+      // Store verification token
+      const { error: tokenError } = await supabase
+        .from('verification_tokens')
+        .upsert(
+          {
+            email: email,
+            code: otp,
+            type: 'email_verification',
+            expires_at: expiresAt
+          },
+          { onConflict: 'email,type' }
+        );
+
+      if (tokenError) {
+        console.error('Verification token error:', tokenError);
+      }
+
+      // Send Verification email
+      await sendVerificationEmail(email, full_name, otp);
+
+      return res.status(201).json({ message: 'Registration successful. Please verify your email.', data });
     } catch (err: any) {
       return res.status(500).json({ error: err.message });
     }
@@ -482,6 +503,113 @@ export const authController = {
     } catch (err: any) {
       console.error('Forgot password error:', err);
       // Return 500 cleanly
+      return res.status(500).json({ error: err.message });
+    }
+  },
+
+  async verifyEmail(req: Request, res: Response) {
+    try {
+      const { email, code } = req.body;
+
+      if (!email || !code) {
+        return res.status(400).json({ error: 'Missing email or code' });
+      }
+
+      const { data: tokenData, error: tokenError } = await supabase
+        .from('verification_tokens')
+        .select('*')
+        .eq('email', email)
+        .eq('code', code)
+        .eq('type', 'email_verification')
+        .single();
+
+      if (tokenError || !tokenData) {
+        return res.status(400).json({ error: 'Invalid or expired verification code' });
+      }
+
+      const expiresAt = new Date(tokenData.expires_at);
+      if (expiresAt < new Date()) {
+        return res.status(400).json({ error: 'Verification code has expired' });
+      }
+
+      // Update client status to Active
+      const { error: updateError } = await supabase
+        .from('clients')
+        .update({ status: 'Active' })
+        .eq('email', email);
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      // Delete the token after successful verification
+      await supabase
+        .from('verification_tokens')
+        .delete()
+        .eq('id', tokenData.id);
+
+      // Fetch user info for welcome email
+      const { data: clientData } = await supabase
+        .from('clients')
+        .select('full_name')
+        .eq('email', email)
+        .single();
+
+      if (clientData) {
+        await sendWelcomeEmail(email, clientData.full_name);
+      }
+
+      return res.status(200).json({ message: 'Email verified successfully' });
+    } catch (err: any) {
+      console.error('Verification error:', err);
+      return res.status(500).json({ error: err.message });
+    }
+  },
+
+  async resendVerification(req: Request, res: Response) {
+    try {
+      const { email } = req.body;
+
+      if (!email) {
+        return res.status(400).json({ error: 'Missing email' });
+      }
+
+      const { data: client, error: clientError } = await supabase
+        .from('clients')
+        .select('full_name, status')
+        .eq('email', email)
+        .single();
+
+      if (clientError || !client) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+
+      if (client.status === 'Active') {
+        return res.status(400).json({ error: 'Email is already verified' });
+      }
+
+      // Generate 6-digit OTP
+      const otp = Math.floor(100000 + Math.random() * 900000).toString();
+      const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+
+      // Upsert verification token
+      await supabase
+        .from('verification_tokens')
+        .upsert(
+          {
+            email: email,
+            code: otp,
+            type: 'email_verification',
+            expires_at: expiresAt
+          },
+          { onConflict: 'email,type' }
+        );
+
+      await sendVerificationEmail(email, client.full_name, otp);
+
+      return res.status(200).json({ message: 'Verification code resent' });
+    } catch (err: any) {
+      console.error('Resend verification error:', err);
       return res.status(500).json({ error: err.message });
     }
   }

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -7,6 +7,8 @@ const router = Router();
 
 router.post('/login', authController.login);
 router.post('/register', authController.registerClient);
+router.post('/verify-email', authController.verifyEmail);
+router.post('/resend-verification', authController.resendVerification);
 router.post('/forgot-password', authController.forgotPassword);
 router.post('/provision', withAuth, requireRole(['superadmin', 'admin', 'workforce-admin']), authController.provision);
 

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -104,9 +104,31 @@ export default function RegisterPage() {
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
+
+    const formData = new FormData(e.target as HTMLFormElement);
+    const email = formData.get('email') as string;
+    const password = formData.get('password') as string;
+    const first_name = formData.get('first-name') as string;
+    const last_name = formData.get('last-name') as string;
+    const contact_number = contactNumber;
+
     try {
-      // TODO: replace with real API call
-      await new Promise(res => setTimeout(res, 800));
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || "https://seebu.onrender.com"}/api/v1/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          password,
+          full_name: `${first_name} ${last_name}`,
+          contact_number
+        })
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Registration failed');
+
+      // Store email for verification step
+      localStorage.setItem('pending_verification_email', email);
 
       // Navigate immediately — React will suspend and show the destination's loading.tsx
       router.push('/auth/verify');
@@ -117,9 +139,9 @@ export default function RegisterPage() {
           description: "Check your email to verify your account.",
         });
       }, 50);
-    } catch {
+    } catch (err: any) {
       gooeyToast.error("Sign Up Failed", {
-        description: "Something went wrong. Please try again.",
+        description: err.message || "Something went wrong. Please try again.",
       });
     } finally {
       setIsLoading(false);
@@ -179,6 +201,7 @@ export default function RegisterPage() {
                 <div className="floating-input">
                   <input 
                     id="first-name" 
+                    name="first-name"
                     type="text"
                     placeholder=" "
                     required 
@@ -192,6 +215,7 @@ export default function RegisterPage() {
                 <div className="floating-input">
                   <input 
                     id="last-name" 
+                    name="last-name"
                     type="text"
                     placeholder=" "
                     required 
@@ -206,6 +230,7 @@ export default function RegisterPage() {
               <div className="floating-input">
                 <input 
                   id="email" 
+                  name="email"
                   type="email"
                   placeholder=" "
                   required 
@@ -237,6 +262,7 @@ export default function RegisterPage() {
               <div className="floating-input has-right-icon">
                 <input 
                   id="password" 
+                  name="password"
                   type={showPassword ? 'text' : 'password'}
                   placeholder=" "
                   required 

--- a/src/app/auth/verify/page.tsx
+++ b/src/app/auth/verify/page.tsx
@@ -11,10 +11,12 @@ import { gooeyToast } from "goey-toast";
 
 export default function VerifyPage() {
   const [code, setCode] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
 
-  const handleVerify = (e: React.FormEvent) => {
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
     try {
-      e.preventDefault();
       if (code.length !== 6) {
         gooeyToast.error("Invalid Code", {
           description: "Please enter a valid 6-digit verification code.",
@@ -22,33 +24,70 @@ export default function VerifyPage() {
         return;
       }
 
-      // Simulate verification
+      const email = localStorage.getItem('pending_verification_email');
+      if (!email) {
+        gooeyToast.error("Missing Email", {
+          description: "Please register again or check your email for the verification link.",
+        });
+        return;
+      }
+
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || "https://seebu.onrender.com"}/api/v1/auth/verify-email`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, code })
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Verification failed');
+
       gooeyToast.success("Verification Successful!", {
         description: "Your account has been verified. Redirecting to login...",
       });
+
+      localStorage.removeItem('pending_verification_email');
 
       // Redirect after delay
       setTimeout(() => {
         window.location.href = "/auth/login";
       }, 2000);
-    } catch (error) {
+    } catch (err: any) {
       gooeyToast.error("Verification Failed", {
-        description: "Something went wrong while verifying your account. Please try again.",
+        description: err.message || "Something went wrong while verifying your account. Please try again.",
       });
-      console.error("Verify flow error:", error);
+      console.error("Verify flow error:", err);
+    } finally {
+      setIsLoading(false);
     }
   };
 
-  const handleResend = () => {
+  const handleResend = async () => {
     try {
+      const email = localStorage.getItem('pending_verification_email');
+      if (!email) {
+        gooeyToast.error("Missing Email", {
+          description: "Please register again.",
+        });
+        return;
+      }
+
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || "https://seebu.onrender.com"}/api/v1/auth/resend-verification`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to resend code');
+
       gooeyToast.success("Code Sent!", {
         description: "A new verification code has been sent to your email.",
       });
-    } catch (error) {
+    } catch (err: any) {
       gooeyToast.error("Resend Failed", {
-        description: "Unable to resend verification code right now. Please try again.",
+        description: err.message || "Unable to resend verification code right now. Please try again.",
       });
-      console.error("Resend flow error:", error);
+      console.error("Resend flow error:", err);
     }
   };
   const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -128,8 +167,12 @@ export default function VerifyPage() {
                 <span className="material-symbols-outlined input-icon">pin</span>
               </div>
 
-              <Button className="w-full h-12 text-lg bg-primary hover:bg-primary-dark text-white font-bold shadow-lg" type="submit">
-                Verify Account
+              <Button
+                className="w-full h-12 text-lg bg-primary hover:bg-primary-dark text-white font-bold shadow-lg disabled:opacity-60"
+                type="submit"
+                disabled={isLoading}
+              >
+                {isLoading ? "Verifying…" : "Verify Account"}
               </Button>
             </form>
 


### PR DESCRIPTION
I have implemented the missing email verification flow for new client signups. 

Changes include:
- **Backend**:
  - Modified `authController.registerClient` to change the initial client status to `Pending`.
  - Added logic to generate a 6-digit OTP, store it in the `verification_tokens` table, and send it via email using Resend.
  - Implemented `verifyEmail` and `resendVerification` methods in `authController.ts`.
  - Registered the new verification routes in `authRoutes.ts`.
- **Frontend**:
  - Updated `src/app/auth/register/page.tsx` to use the real registration API and navigate to the verification page upon success.
  - Updated `src/app/auth/verify/page.tsx` to handle code verification and resending of verification emails.
  - Added `name` attributes to registration form inputs for proper data extraction.
- **Maintenance**:
  - Verified the flow using Playwright scripts with mocked API responses to ensure UI/UX consistency.
  - Cleaned up development artifacts.

---
*PR created automatically by Jules for task [1057094958519436665](https://jules.google.com/task/1057094958519436665) started by @Prannsss*